### PR TITLE
add php enums support in GetValueHashFeature and small fixies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .env
 .phpunit.result.cache
 .php-cs-fixer.cache
+/.phpunit.cache/test-results

--- a/README.md
+++ b/README.md
@@ -779,6 +779,6 @@ You can check the [actions](https://github.com/lapaliv/laravel-bulk-upsert/actio
 ```shell
 git clone https://github.com/lapaliv/laravel-bulk-upsert.git
 cp .env.example .env
-docker-composer up -d
+docker-compose up -d
 ./vendor/bin/phpunit
 ```

--- a/src/Features/GetValueHashFeature.php
+++ b/src/Features/GetValueHashFeature.php
@@ -9,6 +9,6 @@ class GetValueHashFeature
 {
     public function handle(mixed $value): string
     {
-        return hash('crc32c', $value . ':' . gettype($value));
+        return hash('crc32c', ($value->value ?? $value) . ':' . gettype($value));
     }
 }


### PR DESCRIPTION
PHP enums do not implement the __toString magic method and cannot be implicitly converted to a string. 
[PHP RFC: Auto-implement Stringable for string backed enums](https://wiki.php.net/rfc/auto-implement_stringable_for_string_backed_enums)

However, we can use an enum as a composite unique key when working with the database. 
`->uniqueBy(['user_id', 'role'])`
In this case, if we specified an enum in the casts model, we would get an error "Object of class Enum could not be converted to string" in the GetValueHashFeature feature.

```
class Role extends Model
{
    ...
    
    protected $casts = [
         'role' => RoleEnum::class,
    ];
    
    ...
}
```
