### PR TITLE
Fix/mixed value to scalar

### DIFF
--- a/src/Converters/MixedValueToScalarConverter.php
+++ b/src/Converters/MixedValueToScalarConverter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lapaliv\BulkUpsert\Converters;
+
+use Lapaliv\BulkUpsert\Exceptions\BulkValueTypeIsNotSupported;
+
+class MixedValueToScalarConverter
+{
+    public function handle(mixed $value): int|float|bool|string
+    {
+        if (is_scalar($value) || $value === null) {
+            return $value;
+        } elseif (is_object($value) && PHP_VERSION_ID >= 80100 && enum_exists(get_class($value))) {
+            return $value->value;
+        } elseif (is_object($value) && method_exists($value, '__toString')) {
+            $value->__toString();
+        } else {
+            throw new BulkValueTypeIsNotSupported($value);
+        }
+    }
+}

--- a/src/Converters/MixedValueToSqlConverter.php
+++ b/src/Converters/MixedValueToSqlConverter.php
@@ -12,6 +12,13 @@ use Lapaliv\BulkUpsert\Builders\Clauses\BuilderRawExpression;
  */
 class MixedValueToSqlConverter
 {
+    public function __construct(
+        private MixedValueToScalarConverter $mixedValueToScalarConverter
+    )
+    {
+        //
+    }
+
     /**
      * @param mixed $value
      * @param mixed[] $bindings
@@ -46,7 +53,7 @@ class MixedValueToSqlConverter
             return 'null';
         }
 
-        $bindings[] = $value;
+        $bindings[] = $this->mixedValueToScalarConverter->handle($value);
 
         return '?';
     }

--- a/src/Features/GetUniqueKeyFeature.php
+++ b/src/Features/GetUniqueKeyFeature.php
@@ -3,13 +3,17 @@
 namespace Lapaliv\BulkUpsert\Features;
 
 use Illuminate\Database\Eloquent\Model;
+use Lapaliv\BulkUpsert\Converters\MixedValueToScalarConverter;
 
 /**
  * @internal
  */
 class GetUniqueKeyFeature
 {
-    public function __construct(private GetValueHashFeature $getValueHashFeature)
+    public function __construct(
+        private GetValueHashFeature $getValueHashFeature,
+        private MixedValueToScalarConverter $mixedValueToScalarConverter
+    )
     {
         //
     }
@@ -26,7 +30,9 @@ class GetUniqueKeyFeature
 
         foreach ($attributes as $attribute) {
             if ($row instanceof Model) {
-                $key .= $row->getAttribute($attribute);
+                $key .= $this->mixedValueToScalarConverter->handle(
+                    $row->getAttribute($attribute)
+                );
             } else {
                 $key .= $row[$attribute];
             }

--- a/src/Features/GetValueHashFeature.php
+++ b/src/Features/GetValueHashFeature.php
@@ -2,13 +2,20 @@
 
 namespace Lapaliv\BulkUpsert\Features;
 
+use Lapaliv\BulkUpsert\Converters\MixedValueToScalarConverter;
+
 /**
  * @internal
  */
 class GetValueHashFeature
 {
+    public function __construct(private MixedValueToScalarConverter $mixedValueToScalarConverter)
+    {
+        //
+    }
+
     public function handle(mixed $value): string
     {
-        return hash('crc32c', ($value->value ?? $value) . ':' . gettype($value));
+        return hash('crc32c', $this->mixedValueToScalarConverter->handle($value) . ':' . gettype($value));
     }
 }

--- a/src/Providers/BulkUpsertServiceProvider.php
+++ b/src/Providers/BulkUpsertServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
 use Lapaliv\BulkUpsert\BulkBulkDriverManager;
 use Lapaliv\BulkUpsert\Contracts\BulkDriverManager;
+use Lapaliv\BulkUpsert\Converters\MixedValueToScalarConverter;
 use Lapaliv\BulkUpsert\Drivers\MySqlBulkDriver;
 use Lapaliv\BulkUpsert\Drivers\PostgreSqlBulkDriver;
 use Lapaliv\BulkUpsert\Drivers\SqLiteBulkDriver;
@@ -31,8 +32,9 @@ class BulkUpsertServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $getValueHashFeature = new GetValueHashFeature();
-        $getUniqueKeyFeature = new GetUniqueKeyFeature($getValueHashFeature);
+        $mixedValueToScalarConverter = new MixedValueToScalarConverter();
+        $getValueHashFeature = new GetValueHashFeature($mixedValueToScalarConverter);
+        $getUniqueKeyFeature = new GetUniqueKeyFeature($getValueHashFeature, $mixedValueToScalarConverter);
 
         $this->app->singleton(BulkDriverManager::class, fn () => new BulkBulkDriverManager());
         $this->app->singleton(GetDateFieldsFeature::class, fn () => new GetDateFieldsFeature());


### PR DESCRIPTION
Fixed a couple of bugs.
1. GetUniqueKeyFeature when using enum -- toString issue.
2. MixedValueToSqlConverter, when using an enum, fixed a problem with SQL binding of non-scalar values such as enums

MixedValueToScalarConverter was created for this purpose. TheGetValueHashFeature was also transferred to the new MixedValueToScalarConverter.